### PR TITLE
v2/setup/fd&hud: prevent last line being ignored

### DIFF
--- a/v2/setup/flight-director.sh
+++ b/v2/setup/flight-director.sh
@@ -56,6 +56,6 @@ sudo docker run --rm \
 # 5) Restart flight-director fleet-units via jenkins for changes to take effect
 
 
-while read line; do
+while read line || [[ -n "$line" ]]; do
     etcdctl set $line
 done < ${HOMEDIR}/.flight-director

--- a/v2/setup/hud.sh
+++ b/v2/setup/hud.sh
@@ -10,6 +10,6 @@ sudo docker run --rm \
 
 # it's expected that these fields are already in the form
 # /KEY/NAMESPACE VALUE
-while read line; do
+while read line || [[ -n "$line" ]]; do
     etcdctl set $line
 done < ${HOMEDIR}/.hud


### PR DESCRIPTION
`read` returns a non-zero exit code on EOF, so the last line of secrets files are sometimes ignored.